### PR TITLE
Prevent false positives when country_code is supplied

### DIFF
--- a/iso4217parse/__init__.py
+++ b/iso4217parse/__init__.py
@@ -177,7 +177,7 @@ def by_symbol(symbol, country_code=None):
 
         if tmp_res:
             return tmp_res
-        if not country_code:
+        if country_code is None:
             return res
 
 
@@ -207,13 +207,13 @@ def by_symbol_match(value, country_code=None):
                 res = [by_alpha3(s)]
             if group == 'name':
                 res = [_data()['name'][s]]
+            if res and country_code is not None:
+                res = [
+                    currency
+                    for currency in res
+                    if country_code in currency.countries
+                ]
             if res:
-                if country_code:
-                    res = [
-                        currency 
-                        for currency in res 
-                        if country_code in currency.countries
-                    ]
                 return res
 
 

--- a/iso4217parse/__init__.py
+++ b/iso4217parse/__init__.py
@@ -177,7 +177,8 @@ def by_symbol(symbol, country_code=None):
 
         if tmp_res:
             return tmp_res
-        return res
+        if not country_code:
+            return res
 
 
 def by_symbol_match(value, country_code=None):
@@ -207,6 +208,12 @@ def by_symbol_match(value, country_code=None):
             if group == 'name':
                 res = [_data()['name'][s]]
             if res:
+                if country_code:
+                    res = [
+                        currency 
+                        for currency in res 
+                        if country_code in currency.countries
+                    ]
                 return res
 
 


### PR DESCRIPTION
Hi,

I've noticed that when a symbol matches (before the correct symbol), you would expect by_symbol to return None if the given country code is not found in the matches. Instead all of the matches are being returned despite not having the supplied country code. This then means that the correct symbol later in the list will not be found as `res` will now have a value.


Liam

Edit: Closes #6 